### PR TITLE
fix(install-env): patch PyFoam vendored six.py for Python 3.12+

### DIFF
--- a/set_hera_environment.sh
+++ b/set_hera_environment.sh
@@ -29,6 +29,15 @@ else
         "${VENV_DIR}/bin/pip" install --upgrade pip
         "${VENV_DIR}/bin/pip" install -r "${SCRIPT_DIR}/requirements.txt"
         "${VENV_DIR}/bin/pip" install -e "${SCRIPT_DIR}"
+
+        # Patch PyFoam's vendored six.py (v1.10 from 2016) which breaks on Python 3.12+.
+        SITE_SIX="$("${VENV_DIR}/bin/python" -c 'import six, pathlib; print(pathlib.Path(six.__file__))' 2>/dev/null)"
+        PYFOAM_SIX="$("${VENV_DIR}/bin/python" -c 'import PyFoam.ThirdParty, pathlib; print(pathlib.Path(PyFoam.ThirdParty.__file__).parent / "six.py")' 2>/dev/null)"
+        if [ -f "${SITE_SIX}" ] && [ -f "${PYFOAM_SIX}" ]; then
+            cp "${SITE_SIX}" "${PYFOAM_SIX}"
+            echo "Patched PyFoam vendored six.py -> ${PYFOAM_SIX}"
+        fi
+
         echo "Virtual environment created and packages installed at ${VENV_DIR}."
     else
         echo "Skipped virtual environment creation."


### PR DESCRIPTION
## Summary
- PyFoam 2023.7 ships a 2016-era `six.py` (v1.10) whose `_SixMetaPathImporter` trick breaks on Python 3.12+, so `from PyFoam.ThirdParty.six.moves import configparser` fails.
- After `pip install`, `set_hera_environment.sh` now overwrites PyFoam's vendored `six.py` with the venv's modern `six` (v1.17+), restoring the import.
- The patch is idempotent and is a no-op if either `six` or `PyFoam.ThirdParty` is missing, so older Python versions and partial installs are unaffected.

## Test plan
- [ ] Fresh install on Ubuntu 24.04 (Python 3.12) via `source set_hera_environment.sh` — verify `python -c "from PyFoam.ThirdParty.six.moves import configparser"` succeeds.
- [ ] Re-run the script on an existing install — verify the patch step is skipped cleanly.
- [ ] Smoke-test a hera command that exercises PyFoam (e.g. the OpenFOAM preprocess path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)