### PR TITLE
feat(rag): offline mode, local HF model cache, native-Ollama setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ RAG_OLLAMA_BASE_URL=http://localhost:11434
 RAG_OLLAMA_MODEL=llama3
 RAG_EMBED_MODEL=BAAI/bge-small-en-v1.5
 RAG_EMBED_DIM=384
+# Offline mode: when true, embeddings must be pre-cached under RAG_MODELS_CACHE_DIR
+# (run `hera-rag-search download-models` once while online to populate it) and
+# Ollama must be reachable at RAG_OLLAMA_BASE_URL (typically a native install).
+RAG_OFFLINE_MODE=false
+RAG_MODELS_CACHE_DIR=~/.pyhera/rag_models
 RAG_API_HOST=0.0.0.0
 RAG_API_PORT=8765
 RAG_ENABLED=false

--- a/Makefile
+++ b/Makefile
@@ -135,16 +135,18 @@ help:
 	@echo "    make docs-deps           Install documentation dependencies"
 	@echo ""
 	@echo "  RAG Search:"
-	@echo "    make rag-setup           Full setup: install + services + model + index"
-	@echo "    make rag-services-up     Start Qdrant + Cassandra + Ollama"
-	@echo "    make rag-services-down   Stop all RAG services"
-	@echo "    make rag-services-status Show RAG service status"
-	@echo "    make rag-index           Build RAG index from docs/ + hera/"
-	@echo "    make rag-reindex         Wipe and rebuild RAG index"
-	@echo "    make rag-search          Search with default query"
-	@echo "    make rag-serve           Start RAG REST API server"
-	@echo "    make rag-serve-watch     Serve + auto re-index on changes"
-	@echo "    make rag-clean           Stop services + remove all data"
+	@echo "    make rag-setup             Full setup: install + services + model + index"
+	@echo "    make rag-services-up       Start Qdrant + Cassandra + Ollama (Docker)"
+	@echo "    make rag-services-up-native  Start Qdrant + Cassandra only (use host Ollama)"
+	@echo "    make rag-services-down     Stop all RAG services"
+	@echo "    make rag-services-status   Show RAG service status"
+	@echo "    make rag-download-models   Pre-cache HF embedding model for offline use"
+	@echo "    make rag-index             Build RAG index from docs/ + hera/"
+	@echo "    make rag-reindex           Wipe and rebuild RAG index"
+	@echo "    make rag-search            Search with default query"
+	@echo "    make rag-serve             Start RAG REST API server"
+	@echo "    make rag-serve-watch       Serve + auto re-index on changes"
+	@echo "    make rag-clean             Stop services + remove all data"
 
 # --- MongoDB ---
 
@@ -480,8 +482,20 @@ rag-ollama-pull:
 rag-services-up: rag-qdrant-up rag-cassandra-up rag-ollama-up
 	@echo "All RAG services running."
 
+# Same as rag-services-up but skips the Ollama container. Use this when you
+# already run Ollama natively on the host (port 11434 would otherwise clash
+# with the container's internal port, which remapping the host port alone
+# does not fix). Point RAG_OLLAMA_BASE_URL at your native Ollama instance.
+rag-services-up-native: rag-qdrant-up rag-cassandra-up
+	@echo "Qdrant + Cassandra running. Using host-installed Ollama at RAG_OLLAMA_BASE_URL."
+
 rag-services-down: rag-qdrant-down rag-cassandra-down rag-ollama-down
 	@echo "All RAG services stopped."
+
+rag-download-models:
+	@echo "Downloading RAG embedding model into local cache..."
+	hera-rag-search download-models
+	@echo "Done. Models are reusable in offline mode."
 
 rag-services-status:
 	@echo "=== RAG Services ==="
@@ -506,4 +520,5 @@ rag-clean: rag-services-down
 
 .PHONY: rag-install rag-qdrant-up rag-qdrant-down rag-cassandra-up rag-cassandra-down \
         rag-ollama-up rag-ollama-down rag-ollama-pull \
-        rag-services-up rag-services-down rag-services-status rag-setup rag-clean
+        rag-services-up rag-services-up-native rag-services-down rag-services-status \
+        rag-setup rag-clean rag-download-models

--- a/hera/__init__.py
+++ b/hera/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.16.1'
+__version__ = '2.16.2'
 __author__ = 'Yehuda Arav'
 __contributors__ = [
     'Eyal Fattal',
@@ -32,6 +32,23 @@ from hera.datalayer.autocache import cacheFunction,clearFunctionCache,clearAllFu
 toolkitHome = ToolkitHome()
 
 """
+2.16.2 (2026-04)
+-----------------
+    RAG:
+        - Local HuggingFace model cache: embedding models are saved to
+          RAG_MODELS_CACHE_DIR (default ~/.pyhera/rag_models) on first
+          download and reloaded from disk on subsequent runs.
+        - Offline mode (RAG_OFFLINE_MODE=true): refuses network fetches and
+          requires the model to be pre-cached; Ollama must be reachable at
+          RAG_OLLAMA_BASE_URL (typically a native install).
+        - New `hera-rag-search download-models` CLI command to populate the
+          cache ahead of going offline.
+        - New `make rag-services-up-native` target brings up Qdrant and
+          Cassandra without the Ollama container, avoiding the port-11434
+          clash with a host-installed Ollama (remapping the host port alone
+          does not fix it).
+        - New `make rag-download-models` target wrapping the CLI.
+
 2.16.1 (2026-03)
 -----------------
     Docstrings:

--- a/hera/bin/hera-rag-search
+++ b/hera/bin/hera-rag-search
@@ -11,6 +11,7 @@ Commands:
     hera-rag-search watch                 watch docs/ for changes
     hera-rag-search serve                 start REST API server
     hera-rag-search serve --with-watcher  serve + watch simultaneously
+    hera-rag-search download-models       pre-download HF models for offline use
 """
 from __future__ import annotations
 from pathlib import Path
@@ -127,6 +128,31 @@ def serve(
         console.print(f"[cyan]Watcher started on {watch_root}[/cyan]")
 
     run_server(host=host, port=port, reload=reload)
+
+
+@app.command("download-models")
+def download_models(
+    model: str = typer.Option(None, "--model", "-m",
+                              help="Override the embedding model name (defaults to RAG_EMBED_MODEL)."),
+):
+    """Download the HuggingFace embedding model into the local cache for offline use."""
+    from hera.utils.rag.indexer import download_embed_model, _local_model_path
+    from hera.utils.rag.config import settings
+
+    if settings.offline_mode:
+        console.print("[red]RAG_OFFLINE_MODE is enabled — refusing to download.[/red]")
+        console.print("Unset it (or run `RAG_OFFLINE_MODE=false`) and retry.")
+        raise typer.Exit(1)
+
+    name = model or settings.embed_model
+    target = _local_model_path(name)
+    if target.exists():
+        console.print(f"[green]Already cached:[/green] {target}")
+        return
+    console.print(f"Downloading [bold]{name}[/bold] to [cyan]{target}[/cyan] ...")
+    with console.status("Fetching..."):
+        path = download_embed_model(name)
+    console.print(f"[green]Saved:[/green] {path}")
 
 
 def main():

--- a/hera/utils/rag/__init__.py
+++ b/hera/utils/rag/__init__.py
@@ -8,7 +8,7 @@ Quick start::
     print(rag.ask("How do I create a project?"))
 """
 from .search import RAGSearch, retrieve
-from .indexer import build_index, update_file, delete_file
+from .indexer import build_index, update_file, delete_file, download_embed_model
 from .config import settings as rag_settings
 
 __all__ = [
@@ -17,5 +17,6 @@ __all__ = [
     "build_index",
     "update_file",
     "delete_file",
+    "download_embed_model",
     "rag_settings",
 ]

--- a/hera/utils/rag/config.py
+++ b/hera/utils/rag/config.py
@@ -27,6 +27,13 @@ class RagSettings(BaseSettings):
     embed_model: str = "BAAI/bge-small-en-v1.5"
     embed_dim: int = 384
 
+    # ── Offline / local model cache ──────────────────────────────────────────
+    # When offline_mode=True, no network fetches are attempted: embedding
+    # models must already exist under models_cache_dir, and the Ollama server
+    # must already be reachable at ollama_base_url (typically a native install).
+    offline_mode: bool = False
+    models_cache_dir: str = "~/.pyhera/rag_models"
+
     # ── Chunking ─────────────────────────────────────────────────────────────
     chunk_size: int = 1_000
     chunk_overlap: int = 150

--- a/hera/utils/rag/indexer.py
+++ b/hera/utils/rag/indexer.py
@@ -110,11 +110,51 @@ def _qdrant() -> QdrantClient:
     return _qdrant_client
 
 
+def _local_model_path(model_name: str) -> Path:
+    """Return the on-disk directory where a HuggingFace model is cached."""
+    return Path(settings.models_cache_dir).expanduser() / model_name.replace("/", "_")
+
+
+def download_embed_model(model_name: str | None = None) -> Path:
+    """Fetch the embedding model from HuggingFace and save a clean local copy.
+
+    Safe to re-run; skips download if the local copy already exists.
+    Returns the local path.
+    """
+    name = model_name or settings.embed_model
+    local = _local_model_path(name)
+    if local.exists():
+        return local
+    local.parent.mkdir(parents=True, exist_ok=True)
+    model = SentenceTransformer(name)
+    model.save(str(local))
+    return local
+
+
 def _embed_model() -> SentenceTransformer:
-    """Get or create the embedding model singleton."""
+    """Get or create the embedding model singleton.
+
+    Loads from the local cache when available. In online mode, a missing
+    model is downloaded from HuggingFace and then saved for offline reuse.
+    In offline mode, a missing model raises instead of reaching the network.
+    """
     global _embedder
     if _embedder is None:
-        _embedder = SentenceTransformer(settings.embed_model)
+        local = _local_model_path(settings.embed_model)
+        if local.exists():
+            _embedder = SentenceTransformer(str(local))
+        elif settings.offline_mode:
+            raise RuntimeError(
+                f"RAG offline mode is enabled, but embedding model "
+                f"'{settings.embed_model}' is not cached at {local}. "
+                f"Run `hera-rag-search download-models` once while online "
+                f"to populate the cache."
+            )
+        else:
+            local.parent.mkdir(parents=True, exist_ok=True)
+            model = SentenceTransformer(settings.embed_model)
+            model.save(str(local))
+            _embedder = model
     return _embedder
 
 


### PR DESCRIPTION
## Summary

- **Non-Docker Ollama support**: new `make rag-services-up-native` brings up Qdrant + Cassandra only, so users with a host-installed Ollama can skip the container and dodge the port-11434 clash (remapping the host port alone doesn't fix it, since the container's internal port is also 11434).
- **Local HuggingFace model cache**: embedding models are saved to `RAG_MODELS_CACHE_DIR` (default `~/.pyhera/rag_models`) on first download and reloaded from disk afterwards.
- **Offline mode**: `RAG_OFFLINE_MODE=true` refuses all network fetches and requires the model to be pre-cached (and Ollama to be reachable at `RAG_OLLAMA_BASE_URL`). New `hera-rag-search download-models` CLI (and `make rag-download-models`) populates the cache while online.

Version bumped to 2.16.2 with matching changelog entry.

## Test plan

- [ ] `make rag-download-models` populates `~/.pyhera/rag_models/BAAI_bge-small-en-v1.5/`
- [ ] Online: `make rag-index` + `make rag-search` still work end-to-end
- [ ] Offline: set `RAG_OFFLINE_MODE=true`, confirm indexing loads the cached model without network, and that a missing-cache scenario produces the actionable error
- [ ] `make rag-services-up-native` starts only Qdrant + Cassandra; native Ollama is used when `RAG_OLLAMA_BASE_URL` points at it
- [ ] `hera-rag-search download-models` refuses with exit 1 when `RAG_OFFLINE_MODE=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)