### PR TITLE
Updating the support for pint in LSM

### DIFF
--- a/hera/__init__.py
+++ b/hera/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.16.2'
+__version__ = '2.16.3'
 __author__ = 'Yehuda Arav'
 __contributors__ = [
     'Eyal Fattal',
@@ -32,6 +32,10 @@ from hera.datalayer.autocache import cacheFunction,clearFunctionCache,clearAllFu
 toolkitHome = ToolkitHome()
 
 """
+2.16.3 (2026-05)
+    LSM: 
+        - The output of the getConcentration and getDosage is always pint. 
+
 2.16.2 (2026-04)
 -----------------
     RAG:

--- a/hera/simulations/LSM/singleSimulation.py
+++ b/hera/simulations/LSM/singleSimulation.py
@@ -32,19 +32,22 @@ class SingleSimulation(object):
             if type(self._finalxarray) is str:
                 self._finalxarray = xarray.open_mfdataset(self._finalxarray, combine='by_coords')
 
-    def getDosage(self, Q=1 * kg, time_units=min, q_units=mg, ret_pint=False):
+    def getDosage(self, Q=1 * ureg.kg, time_units=ureg.min, q_units=ureg.mg):
         """
-        Calculates the dosage
+        Calculates the dosage from the LSM simulation.
+        The default are pint units, but we still support unum inputs.
+
+        The outputs (in the attrs) are always pint.
 
         Parameters
         ----------
-        Q : unum.units
+        Q : pint|unum.units
             Default value is 1*kg
 
-        time_units: unum.units
+        time_units: pint|unum.units
             Default value is min
 
-        q_units: unum.units
+        q_units: pint|unum.units
             Default value is mg
 
         Returns
@@ -75,7 +78,7 @@ class SingleSimulation(object):
 
         return final_xarray
 
-    def getConcentration(self, Q=1*kg, time_units=min, q_units=mg, ret_pint=False):
+    def getConcentration(self, Q=1*ureg.kg, time_units=ureg.min, q_units=ureg.mg):
         """
         Calculates the concentration
 
@@ -95,15 +98,15 @@ class SingleSimulation(object):
         dDosage: xarray
             The calculated concentration in 'C' key
         """
-        finalxarray = self.getDosage(Q=Q, time_units=time_units, q_units=q_units, ret_pint=ret_pint)
+        finalxarray = self.getDosage(Q=Q, time_units=time_units, q_units=q_units)
 
         dDosage = finalxarray['Dosage'].diff('datetime').to_dataset().rename({'Dosage': 'dDosage'})
-        dDosage['C'] = dDosage['dDosage'] / finalxarray.attrs['dt'].asNumber()
+        dDosage['C'] = dDosage['dDosage'] / finalxarray.attrs['dt']
         dDosage.attrs = finalxarray.attrs
 
         return dDosage
 
-    def getConcentrationAtPoint(self, x, y, datetime, Q=1*kg, time_units=min, q_units=mg, ret_pint=False):
+    def getConcentrationAtPoint(self, x, y, datetime, Q=1*ureg.kg, time_units=ureg.min, q_units=ureg.mg):
         """
         Calculates the concentration at requested point and time
 
@@ -123,7 +126,7 @@ class SingleSimulation(object):
         con: float
             The concentration at the requested point and time
         """
-        return self.getConcentration(Q=Q, time_units=time_units, q_units=q_units, ret_pint=ret_pint)['C'].interp(x=x, y=y, datetime=datetime).values[0]
+        return self.getConcentration(Q=Q, time_units=time_units, q_units=q_units)['C'].interp(x=x, y=y, datetime=datetime).values[0]
 
     # def toVTK(self, data, outputdir, name, fields):
     #     from pyevtk.hl import gridToVTK


### PR DESCRIPTION
We removed the return of unum in the LSM 
Unum is still accepted as input. the defaults are pint. 