### PR TITLE
Fix Python 3.9 compatibility in test_notebooks.py using future annota…

### DIFF
--- a/hera/tests/test_notebooks.py
+++ b/hera/tests/test_notebooks.py
@@ -22,6 +22,8 @@ List discovered notebooks without running::
     pytest hera/tests/test_notebooks.py --collect-only
 """
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 


### PR DESCRIPTION
…tions

Production environments on Python 3.9 fail at collection time on the PEP 604 union syntax (e.g. `str | None`) used in this module.  Adding `from __future__ import annotations` defers annotation evaluation so the file imports cleanly on 3.9 while remaining valid on 3.10+.