### PR TITLE
Fix three issues surfaced by full-data test run

### DIFF
--- a/hera/measurements/GIS/utils.py
+++ b/hera/measurements/GIS/utils.py
@@ -300,12 +300,16 @@ class stlFactory:
 
                 # dem facet 1
                 n = numpy.cross(numpy.array(v1) - numpy.array(v2), numpy.array(v1) - numpy.array(v3))
-                n = n / numpy.sqrt(sum(n ** 2))
+                mag = numpy.sqrt(sum(n ** 2))
+                if mag > 0:
+                    n = n / mag
                 stl_str += self._make_facet_str(n, v1, v2, v3)
 
                 # dem facet 2
                 n = numpy.cross(numpy.array(v2) - numpy.array(v3), numpy.array(v2) - numpy.array(v4))
-                n = n / numpy.sqrt(sum(n ** 2))
+                mag = numpy.sqrt(sum(n ** 2))
+                if mag > 0:
+                    n = n / mag
                 # stl_str += self._make_facet_str( n, v2, v3, v4 )
                 stl_str += self._make_facet_str(n, v2, v4, v3)
 

--- a/hera/measurements/meteorology/lowfreqdata/analysis.py
+++ b/hera/measurements/meteorology/lowfreqdata/analysis.py
@@ -78,10 +78,11 @@ class analysis:
             Time=curdata[datecolumn].dt.hour * 100 + curdata[datecolumn].dt.minute
         )
 
-        # 🧠 חלוקה לעונות לפי חודש
+        # 🧠 חלוקה לעונות לפי חודש (December and Jan-Feb both map to Winter; ordered=False
+        # allows the duplicate label without the deprecated .replace on a CategoricalDtype)
         tm = lambda x, field: pd.cut(x[field], [0, 2, 5, 8, 11, 12],
-                                     labels=['Winter', 'Spring', 'Summer', 'Autumn', 'Winter1']) \
-                                     .replace('Winter1', 'Winter')
+                                     labels=['Winter', 'Spring', 'Summer', 'Autumn', 'Winter'],
+                                     ordered=False)
 
         if isinstance(data, dask.dataframe.DataFrame):
             curdata = curdata.map_partitions(lambda df: df.assign(season=tm(df, monthcolumn)))

--- a/hera/tests/test_topography.py
+++ b/hera/tests/test_topography.py
@@ -148,7 +148,7 @@ class TestGetPointListElevation:
         tested_any = False
         for i, row in points.iterrows():
             expected = read_raw_elevation(row["lat"], row["lon"], resource_folders)
-            actual = elevations.iloc[i]
+            actual = elevations["elevation"].iloc[i]
             if expected is not None and actual is not None:
                 assert abs(actual - expected) <= 1
                 tested_any = True


### PR DESCRIPTION
- test_topography.TestGetPointListElevation.test_matches_hgt_files: getPointListElevation returns a DataFrame with columns (filename, lon, lat, elevation). The test was doing `actual = elevations.iloc[i]`, pulling an entire row Series whose filename column is a string — so `abs(actual - expected)` raised TypeError(str - int) when the SAMPLES fix unblocked the test. Select the elevation column directly.

- lowfreqdata/analysis.py: pd.cut(...).replace('Winter1', 'Winter') triggered a FutureWarning because .replace on a CategoricalDtype changes categories and is being deprecated. Use ordered=False with the duplicate 'Winter' label so December folds back into Winter without the replace step. Output values are identical; the resulting Categorical is just unordered (the 'season' column has no callers that depend on ordering).

- GIS/utils.py STL facet normals: `n / sqrt(sum(n**2))` raised RuntimeWarning on degenerate triangles (zero-length cross product). Guard the normalization so n stays as zeros for degenerate facets — same downstream behavior, no warning.