### PR TITLE
Fix DeprecationWarning: use raw string for regex separator in LSM tem…

### DIFF
--- a/hera/simulations/LSM/template.py
+++ b/hera/simulations/LSM/template.py
@@ -372,7 +372,7 @@ class LSMTemplate:
 
         for (i, curData) in enumerate(combined):
             logger.info("\t... reading %s" % curData[0])
-            cur = pandas.read_csv(curData[0], sep="\s+",
+            cur = pandas.read_csv(curData[0], sep=r"\s+",
                                   names=["x", "y", "z", "Dosage"])  # ,dtype={'x':int,'y':int,'z':int,'Dosage':float})
 
             cur['time'] = curData[1]


### PR DESCRIPTION
…plate

Switch sep="\s+" to sep=r"\s+" in pandas.read_csv call to silence Python's invalid-escape-sequence DeprecationWarning surfaced in the test suite.