### PR TITLE
fix: add hera. prefix to broken top-level imports (issue #920)

### DIFF
--- a/hera/simulations/WRF/__init__.py
+++ b/hera/simulations/WRF/__init__.py
@@ -1,1 +1,1 @@
-from simulations.WRF.wrfDatalayer import wrfDatalayer
+from hera.simulations.WRF.wrfDatalayer import wrfDatalayer

--- a/hera/simulations/openFoam/lagrangian/LSM/toolkit.py
+++ b/hera/simulations/openFoam/lagrangian/LSM/toolkit.py
@@ -6,11 +6,11 @@ import numpy
 from dask.delayed import delayed
 from dask import dataframe
 
-from datalayer import datatypes
+from hera.datalayer import datatypes
 
-from simulations.openFoam.toberewritten.utils import getCellDataAndGroundData
-from simulations.utils import coordinateHandler
-from datalayer import nonDBMetadataFrame
+from hera.simulations.openFoam.toberewritten.utils import getCellDataAndGroundData
+from hera.simulations.utils import coordinateHandler
+from hera.datalayer import nonDBMetadataFrame
 from hera.toolkit import toolkitHome
 from .sourcesFactoryTool import sourcesFactoryTool
 from itertools import product

--- a/hera/simulations/openFoam/toberewritten/utils.py
+++ b/hera/simulations/openFoam/toberewritten/utils.py
@@ -1,8 +1,8 @@
 # import pandas
 import numpy
 import os
-from simulations.openFoam import HERAMETADATA
-from utils import loadJSON
+from hera.simulations.openFoam import HERAMETADATA
+from hera.utils import loadJSON
 # from ..utils.coordinateHandler import coordinateHandler
 # handler = coordinateHandler()
 

--- a/hera/simulations/utils/canopyWindProfile.py
+++ b/hera/simulations/utils/canopyWindProfile.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas
 import geopandas
 import os
-from utils.angle import toMathematicalAngle
+from hera.utils.angle import toMathematicalAngle
 
 karman = 0.41
 def urbanLogExponentProfile(cellCenters, lambdaGrid, stations):


### PR DESCRIPTION
Internal modules were imported without the hera. root prefix (e.g. `from utils...` instead of `from hera.utils...`), causing ImportError when hera/hera is not on PYTHONPATH.

Fixes 8 occurrences across 4 files:
- hera/simulations/openFoam/lagrangian/LSM/toolkit.py (4 imports)
- hera/simulations/utils/canopyWindProfile.py (1 import)
- hera/simulations/WRF/__init__.py (1 import)
- hera/simulations/openFoam/toberewritten/utils.py (2 imports)