### PR TITLE
test: ensure unit tests leave zero traces (DB + disk) (#951)

### DIFF
--- a/hera/tests/conftest.py
+++ b/hera/tests/conftest.py
@@ -24,6 +24,7 @@ PREPARE_EXPECTED_OUTPUT : str (env var)
     Set to "1" to generate expected output files instead of comparing.
 """
 
+import glob
 import json
 import math
 import os
@@ -50,6 +51,108 @@ PYTEST_PROJECT_NAME = "PYTEST_HERA_PROJECT"
 
 
 # ---------------------------------------------------------------------------
+# Cleanup primitives — leave ZERO traces (DB documents + on-disk directories)
+# ---------------------------------------------------------------------------
+#
+# A Hera project "exists" (appears in ``getProjectList``) as long as ANY
+# document carries its ``projectName`` — including the hidden
+# ``<projectName>__config__`` Cache document that ``Project`` creates on
+# construction.  Deleting only measurement/simulation documents therefore
+# leaks the project.  On disk, ``Project.__init__`` unconditionally creates
+# ``~/.hera/<projectName>`` (or whatever ``filesDirectory`` resolves to) and
+# never removes it.  These helpers tear down both halves completely.
+
+# Projects that must never be purged (shared / framework-owned).
+_PROTECTED_PROJECTS = frozenset({"", "defaultProject"})
+
+# Unambiguous project-name patterns owned by the test suite.  Projects matching
+# these are safe to purge even if they predate the session (they are leftovers
+# from earlier, incompletely-cleaned runs).
+_TEST_PROJECT_PREFIXES = ("pytest_", "unittest_project_dynamic_")
+_TEST_PROJECT_EXACT = frozenset({"PYTEST_HERA_PROJECT", "REPOSITORY_PROJECT_TESTING_01"})
+
+
+def _is_test_project(projectName):
+    """True if a project name is unambiguously created by this test suite."""
+    if projectName in _PROTECTED_PROJECTS:
+        return False
+    if projectName in _TEST_PROJECT_EXACT:
+        return True
+    return any(projectName.startswith(p) for p in _TEST_PROJECT_PREFIXES)
+
+
+def purge_project_db(projectName):
+    """Delete every document of a project across all three collections.
+
+    Uses the collection layer directly (NOT ``Project(...)``) so the purge has
+    no side effects — constructing a ``Project`` would re-create the
+    ``__config__`` document and its files directory.  Removing the config
+    document is what actually makes the project disappear from
+    ``getProjectList``.
+    """
+    if projectName in _PROTECTED_PROJECTS:
+        return
+    try:
+        from hera.datalayer.collection import AbstractCollection
+        # AbstractCollection (type=None) spans Measurements + Simulations + Cache.
+        AbstractCollection().deleteDocuments(projectName=projectName)
+    except Exception:
+        pass
+
+
+def purge_project_dirs(projectName):
+    """Remove the on-disk directories a project may have created.
+
+    Covers the default ``~/.hera/<projectName>`` location and a stray
+    ``<cwd>/<projectName>`` directory (produced by historically relative
+    ``filesDirectory`` configurations).
+    """
+    if projectName in _PROTECTED_PROJECTS:
+        return
+    candidates = [
+        os.path.join(os.path.expanduser("~"), ".hera", projectName),
+        os.path.join(os.getcwd(), projectName),
+    ]
+    for d in candidates:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def purge_project(projectName):
+    """Full teardown for a project: DB documents first, then on-disk directories.
+
+    Order matters: the config document is deleted *before* the directories so
+    that no lingering ``filesDirectory`` config can resurrect a directory via a
+    later ``Project`` construction.
+    """
+    purge_project_db(projectName)
+    purge_project_dirs(projectName)
+
+
+def purge_test_disk_artifacts():
+    """Remove on-disk directories left by the test suite, matched by name.
+
+    Runs independently of DB state: a project may be cleaned from MongoDB by
+    its own fixture teardown yet still leave a directory behind (e.g. when an
+    old, relative ``filesDirectory`` config pointed it at the current working
+    directory).  Also sweeps the temporary ``filesDirectory`` trees created by
+    the session/function fixtures.
+    """
+    # Test-named project directories under ~/.hera and the working directory.
+    for root in (os.path.join(os.path.expanduser("~"), ".hera"), os.getcwd()):
+        if not os.path.isdir(root):
+            continue
+        for entry in os.listdir(root):
+            full = os.path.join(root, entry)
+            if os.path.isdir(full) and _is_test_project(entry):
+                shutil.rmtree(full, ignore_errors=True)
+
+    # Temporary files-directory trees created by the test fixtures.
+    for pattern in ("hera_pytest_main_*", "hera_pytest_func_*", "hera_exp_test_*"):
+        for d in glob.glob(os.path.join(tempfile.gettempdir(), pattern)):
+            shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # CLI option: --result-set
 # ---------------------------------------------------------------------------
 
@@ -60,6 +163,54 @@ def pytest_addoption(parser):
         default=None,
         help="Name of the expected-output result set (overrides RESULT_SET env var).",
     )
+
+
+# ---------------------------------------------------------------------------
+# Session safety-net: guarantee zero leaked projects / directories
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def _no_trace_guard():
+    """Purge every project created during the test session.
+
+    This is a defense-in-depth backstop: individual fixtures clean up after
+    themselves, but tests that create projects directly (or via CLI / notebook
+    subprocesses, e.g. ``unittest_project_dynamic_<pid>``) can still slip
+    through.  We snapshot the project list at session start and, at the end,
+    purge anything that appeared during the session.
+
+    Only *newly created* projects are touched — anything that already existed
+    before the session is left completely alone, so this can never disturb a
+    developer's pre-existing data.
+    """
+    from hera.datalayer.project import getProjectList
+
+    try:
+        before = set(getProjectList())
+    except Exception:
+        before = set()
+
+    yield
+
+    try:
+        after = set(getProjectList())
+    except Exception:
+        return
+
+    # Purge (a) every project created during this session, plus (b) any project
+    # matching a known test-name pattern — the latter mops up leftovers from
+    # earlier incompletely-cleaned runs.  Pre-existing projects that are NOT
+    # test artifacts are never touched.
+    new_projects = after - before
+    leftover_test_projects = {p for p in after if _is_test_project(p)}
+    for projectName in sorted(new_projects | leftover_test_projects):
+        if projectName in _PROTECTED_PROJECTS:
+            continue
+        purge_project(projectName)
+
+    # Sweep disk artifacts whose owning project was already removed from the DB
+    # by its own fixture teardown (so the loop above never saw it).
+    purge_test_disk_artifacts()
 
 
 # ---------------------------------------------------------------------------
@@ -130,12 +281,11 @@ def hera_test_project(test_hera_root):
 
     basedir = str(test_hera_root)
 
-    # Create the project, then forcibly redirect its files directory to /tmp
-    # so test runs never litter the repository root.
+    # Point the project's files directory at /tmp from the start so test runs
+    # never litter ``~/.hera`` or the repository root.  Passing ``filesDirectory``
+    # to the constructor means ``~/.hera/<projectName>`` is never created.
     _files_tmp = tempfile.mkdtemp(prefix="hera_pytest_main_")
-    proj = Project(projectName=PYTEST_PROJECT_NAME)
-    proj._FilesDirectory = _files_tmp
-    proj.setConfig(filesDirectory=_files_tmp)
+    proj = Project(projectName=PYTEST_PROJECT_NAME, filesDirectory=_files_tmp)
 
     # Load all datasources + configs into the project
     dt = dataToolkit()
@@ -148,12 +298,12 @@ def hera_test_project(test_hera_root):
 
     yield proj
 
-    # Teardown: remove all documents created during the session
-    try:
-        for doc in proj.getMeasurementsDocuments():
-            doc.delete()
-    except Exception:
-        pass
+    # Teardown: delete ALL documents (incl. the __config__ doc) so the project
+    # disappears entirely, THEN remove the temporary files directory.  Deleting
+    # the config first prevents any later Project() open from resurrecting the
+    # directory via its saved filesDirectory.
+    purge_project_db(PYTEST_PROJECT_NAME)
+    purge_project_dirs(PYTEST_PROJECT_NAME)
     shutil.rmtree(_files_tmp, ignore_errors=True)
 
 
@@ -213,16 +363,11 @@ def project_fixture():
 
     project_name = "pytest_temp_project"
     _files_tmp = tempfile.mkdtemp(prefix="hera_pytest_func_")
-    proj = Project(projectName=project_name)
-    proj._FilesDirectory = _files_tmp
-    proj.setConfig(filesDirectory=_files_tmp)
+    proj = Project(projectName=project_name, filesDirectory=_files_tmp)
     yield proj
-    # Cleanup: remove all documents created during the test
-    try:
-        for doc in proj.getMeasurementsDocuments():
-            doc.delete()
-    except Exception:
-        pass
+    # Cleanup: delete ALL documents (incl. config) then the files directory.
+    purge_project_db(project_name)
+    purge_project_dirs(project_name)
     shutil.rmtree(_files_tmp, ignore_errors=True)
 
 

--- a/hera/tests/dynamic_loading_tests_pack/conftest.py
+++ b/hera/tests/dynamic_loading_tests_pack/conftest.py
@@ -154,6 +154,13 @@ def load_dummy_experiment_to_project(hera_repo_root, dummy_experiment_dir, temp_
         "experiment_dir": str(dummy_experiment_dir),
     }
 
-    # Teardown: delete the project's files directory (~/.hera/<project_name>)
+    # Teardown: remove ALL DB documents for the project (incl. the hidden
+    # ``<name>__config__`` doc, so it no longer appears in getProjectList),
+    # then delete its files directory (~/.hera/<project_name>).
+    try:
+        from hera.datalayer.collection import AbstractCollection
+        AbstractCollection().deleteDocuments(projectName=temp_project_name)
+    except Exception:
+        pass
     project_files_dir = os.path.join(os.path.expanduser("~"), ".hera", temp_project_name)
     shutil.rmtree(project_files_dir, ignore_errors=True)


### PR DESCRIPTION
Tests were leaking MongoDB projects and on-disk directories:

- A project stays in getProjectList() as long as any document carries its name, including the hidden <projectName>__config__ Cache document created on every Project() construction. Teardowns deleted only measurement docs, so the config doc kept every project alive.
- Project.__init__ unconditionally creates ~/.hera/<projectName>; nothing removed it.
- The session fixture persisted an ephemeral mkdtemp path into the durable DB config, so later Project() opens resurrected the tmp dir via makedirs.

Fix:
- Add purge primitives that delete all docs (incl. the config doc, via the collection layer) and remove on-disk dirs.
- Add a session-scoped autouse safety-net that purges every project created during the session plus leftover test-named projects/dirs. Only touches test artifacts; defaultProject and pre-existing data are never modified.
- Pass filesDirectory at construction so ~/.hera/<name> is never created, and purge the config doc on teardown so tmp dirs cannot be resurrected.
- dynamic_loading conftest now purges the DB, not just the disk dir.

Verified: 275 passed; zero new DB/dir/tmp artifacts; idempotent across runs.